### PR TITLE
fix accessible issue when hand is at end

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "homepage": "https://github.com/kurtextrem/js-sieve#readme",
   "devDependencies": {
+    "@types/node": "^20.11.19",
     "esno": "^4.0.0",
     "obliterator": "^2.0.4",
     "tinybench": "^2.5.1",

--- a/sieve.mts
+++ b/sieve.mts
@@ -73,12 +73,12 @@ export class Sieve<K, V> {
     }
 
     private evict(): void {
-        if (!this.hand) {
+        if (!this.hand || !this.hand.isAccessible()) {
             this.hand = this.ll.rBegin(); // start on tail
         }
 
         let i: Entry<K, V>;
-        while (this.hand.isAccessible() && (i = this.hand.pointer) && i.visited) {
+        while ((i = this.hand.pointer) && i.visited) {
             i.visited = false;
 
             this.hand.next(); // as we use `rBegin`, this is actually the prev node
@@ -87,12 +87,7 @@ export class Sieve<K, V> {
             }
         }
 
-        const hand = this.hand;
-        if (hand.isAccessible()) {
-            this.items.delete(hand.pointer.key);
-            this.ll.eraseElementByIterator(hand);
-            return;
-        }
-        this.hand = undefined;
+        this.items.delete(this.hand.pointer.key);
+        this.ll.eraseElementByIterator(this.hand);
     }
 }

--- a/test/index.mts
+++ b/test/index.mts
@@ -1,17 +1,29 @@
-import { Sieve  } from '../list.mts'
+import { strictEqual } from "assert";
+import { Sieve } from "../sieve.mts";
 
-const list = new Sieve<string, string>(2)
-list.set('a', 'a')
-list.set('b', 'b')
-list.set('c', 'c')
-console.log(list.len() === 2)
-console.log(list.contains('b'))
-console.log(list.contains('c'))
-console.log(!list.contains('a')) // FIFO
+let sieve = new Sieve<string, string>(2);
+sieve.set("a", "a");
+sieve.set("b", "b");
+sieve.set("c", "c");
+strictEqual(sieve.len(), 2);
+strictEqual(sieve.contains("b"), true);
+strictEqual(sieve.contains("c"), true);
+// FIFO
+strictEqual(sieve.contains("a"), false);
 
-list.get('b') // visit
-list.set('a', 'a')
-console.log(list.len() === 2)
-console.log(list.contains('b'))
-console.log(!list.contains('c')) // no longer FIFO because of the visit
-console.log(list.contains('a'))
+// visit
+sieve.get("b");
+sieve.set("a", "a");
+strictEqual(sieve.len(), 2);
+strictEqual(sieve.contains("b"), true);
+// no longer FIFO because of the visit
+strictEqual(sieve.contains("c"), false);
+strictEqual(sieve.contains("a"), true);
+
+sieve = new Sieve<string, string>(2);
+sieve.set("a", "a");
+sieve.get("a");
+sieve.set("c", "c");
+sieve.set("b", "b");
+sieve.set("c", "c");
+strictEqual(sieve.len(), 2);


### PR DESCRIPTION
While debugging the hit ratio differences reported by https://github.com/NeoPhi/sieve-bench I noticed that under certain cases the size of the sieve would exceed the maximum. This seemed to be related to when the hand is at the head of the list. I added a minimal test case and a fix.